### PR TITLE
merged with the latest master at jbossas/patch-gen

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,19 @@ In the following sections, substitute `patch-gen` for `java -jar patch-gen-*-sha
 
     alias patch-gen='java -jar patch-gen-*-shaded.jar'
 
-### Patch Generation
-    patch-gen --applies-to-dist=~/wildfly/wildfly-8.0.0.Final --updated-dist=~/wildfly/wildfly-8.1.0.CR2 --patch-config=patch-config-wildfly-CR2-patch.xml --output-file=wildfly-8.1.0.CR2.patch.zip
+## Patch Generation
+    patch-gen --applies-to-dist=~/wildfly/wildfly-8.0.0.Final --updated-dist=~/wildfly/wildfly-8.0.1.Final --patch-config=wildfly-8.0.1.Final-patch.xml --output-file=wildfly-8.0.1.Final.patch.zip
 
 `--applies-to-dist` and `--updated-dist` must point exactly at the root of the distributions (the directory containing bin, modules, domain, etc.), otherwise the tool will crash.
+
+### Generation of patches containing multiple CPs
+
+    patch-gen --applies-to-dist=~/wildfly/wildfly-8.0.1.Final --updated-dist=~/wildfly/wildfly-8.0.2.Final --patch-config=wildfly-8.0.2.Final-patch.xml --output-file=wildfly-8.0.2.Final.patch.zip --combine-with=wildfly-8.0.1.Final.patch.zip
+
+where wildfly-8.0.1.Final.patch.zip is the last produced CP (in this example generated in the section above) for wildfly-8.0.0.Final.
+The generated patch wildfly-8.0.2.Final.patch.zip can be applied to wildfly-8.0.1.Final as well as to wildfly-8.0.0.Final.
+No matter to which version it is applied, the resulting patched version will be wildfly-8.0.2.Final.
+There is no restriction on the number of CPs included into a single patch file.
 
 ### Configuration Templating
 
@@ -44,10 +53,10 @@ $EDITOR patch-config-wildfly-CR2-patch.xml
 ```xml
 <?xml version='1.0' encoding='UTF-8'?>
 <patch-config xmlns="urn:jboss:patch-config:1.0">
-   <name>wildfly-CR2</name>
-   <description>WildFly 8.1.0.CR2 patch</description>
+   <name>wildfly-8.0.2.Final.patch</name>
+   <description>WildFly 8.0.2.Final patch</description>
    <cumulative  />
-   <element patch-id="base-wildfly-CR2-patch">
+   <element patch-id="base-wildfly-8.0.2.Final-patch">
       <cumulative name="base" />
       <description>No description available</description>
    </element>

--- a/pom.xml
+++ b/pom.xml
@@ -12,10 +12,10 @@
 
     <groupId>org.jboss.as</groupId>
     <artifactId>patch-gen</artifactId>
-    <version>1.0.0.Alpha1-SNAPSHOT</version>
+    <version>2.0.0.Alpha1-SNAPSHOT</version>
 
     <name>jboss patch-gen tool</name>
-    <description>The patch patch-gen tool</description>
+    <description>The patch-gen tool</description>
 
     <properties>
         <!-- Build configuration -->
@@ -33,7 +33,7 @@
             For example: <version.org.jboss.as.console>
          -->
 
-        <version.org.wildfly>7.3.1.Final-redhat-2</version.org.wildfly>
+        <version.org.wildfly-core>2.0.0.CR6</version.org.wildfly-core>
         <version.junit>4.11</version.junit>
 
         <!-- Surefire args -->
@@ -136,9 +136,9 @@
     <dependencies>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-patching</artifactId>
-            <version>${version.org.wildfly}</version>
+            <version>${version.org.wildfly-core}</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/jboss/as/patching/generator/OptionalPath.java
+++ b/src/main/java/org/jboss/as/patching/generator/OptionalPath.java
@@ -1,0 +1,97 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.patching.generator;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public class OptionalPath {
+
+    public static OptionalPath create(String path) {
+        return new OptionalPath(path, null);
+    }
+
+    public static OptionalPath create(String path, String requires) {
+        return new OptionalPath(path, requires);
+    }
+
+    private final String value;
+    private final String requires;
+
+    OptionalPath(String value, String requires) {
+        assert value != null : "value is null";
+        this.value = value;
+        this.requires = requires;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public String getRequires() {
+        return requires;
+    }
+
+    /* (non-Javadoc)
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((requires == null) ? 0 : requires.hashCode());
+        result = prime * result + ((value == null) ? 0 : value.hashCode());
+        return result;
+    }
+
+    /* (non-Javadoc)
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        OptionalPath other = (OptionalPath) obj;
+        if (requires == null) {
+            if (other.requires != null)
+                return false;
+        } else if (!requires.equals(other.requires))
+            return false;
+        if (value == null) {
+            if (other.value != null)
+                return false;
+        } else if (!value.equals(other.value))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "[" + value + " requires " + requires + "]";
+    }
+}

--- a/src/main/java/org/jboss/as/patching/generator/PatchBuilderWrapper.java
+++ b/src/main/java/org/jboss/as/patching/generator/PatchBuilderWrapper.java
@@ -24,14 +24,19 @@ package org.jboss.as.patching.generator;
 
 import static org.jboss.as.patching.generator.PatchGenerator.processingError;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.jboss.as.patching.metadata.MiscContentItem;
 import org.jboss.as.patching.metadata.ModificationBuilderTarget;
+import org.jboss.as.patching.metadata.ModificationCondition;
 import org.jboss.as.patching.metadata.Patch;
 import org.jboss.as.patching.metadata.PatchBuilder;
 import org.jboss.as.patching.metadata.PatchElementBuilder;
@@ -43,8 +48,21 @@ import org.jboss.as.patching.metadata.PatchElementBuilder;
  */
 abstract class PatchBuilderWrapper extends PatchBuilder {
 
+
+    private FSPathElement optionalPaths = new FSPathElement("root");
+
     protected PatchBuilderWrapper() {
         //
+    }
+
+    void setOptionalPaths(Collection<OptionalPath> optionalPaths) {
+        for(OptionalPath path : optionalPaths) {
+            final String[] split = path.getValue().split("/");
+            final FSPathElement e = this.optionalPaths.addChild(split);
+            if(path.getRequires() != null) {
+                e.requires = path.getRequires().split("/");
+            }
+        }
     }
 
     abstract PatchElementBuilder modifyLayer(final String name, final boolean addOn);
@@ -133,7 +151,8 @@ abstract class PatchBuilderWrapper extends PatchBuilder {
         // Compare misc files
         final DistributionContentItem or = original.getRoot();
         final DistributionContentItem nr = updated.getRoot();
-        compareMiscFiles(builder, or, nr);
+
+        compareMiscFiles(builder, or, nr, builder.optionalPaths);
 
         // Compare layers
         final Set<String> originalLayers = new LinkedHashSet<String>(original.getLayers());
@@ -151,7 +170,7 @@ abstract class PatchBuilderWrapper extends PatchBuilder {
                 updatedLayer = null;
             }
             //
-            compareLayer(elementBuilder, originalLayer, updatedLayer, includeVersion);
+            compareLayer(layer, elementBuilder, originalLayer, updatedLayer, includeVersion);
         }
 
         for (final String layer : updatedLayers) {
@@ -159,7 +178,7 @@ abstract class PatchBuilderWrapper extends PatchBuilder {
             final Distribution.ProcessedLayer updatedLayer = updated.getLayer(layer);
             final PatchElementBuilder elementBuilder = builder.addLayer(layer);
             //
-            compareLayer(elementBuilder, originalLayer, updatedLayer, includeVersion);
+            compareLayer(layer, elementBuilder, originalLayer, updatedLayer, includeVersion);
         }
 
         // Compare add-ons
@@ -178,12 +197,12 @@ abstract class PatchBuilderWrapper extends PatchBuilder {
                 updatedLayer = null;
             }
             //
-            compareLayer(elementBuilder, originalLayer, updatedLayer, includeVersion);
+            compareLayer(addOn, elementBuilder, originalLayer, updatedLayer, includeVersion);
         }
 
         for (final String addOn : updatedAddOns) {
             final PatchElementBuilder elementBuilder = builder.addAddOn(addOn);
-            compareLayer(elementBuilder, null, updated.getAddOn(addOn), includeVersion);
+            compareLayer(addOn, elementBuilder, null, updated.getAddOn(addOn), includeVersion);
         }
 
     }
@@ -195,9 +214,10 @@ abstract class PatchBuilderWrapper extends PatchBuilder {
      * @param originalLayer  the original layer
      * @param updatedLayer   the updated layer
      */
-    static void compareLayer(final PatchElementBuilder elementBuilder, final Distribution.ProcessedLayer originalLayer, final Distribution.ProcessedLayer updatedLayer, boolean includeVersion) {
-        compareModuleItems(elementBuilder, originalLayer.getModules(), updatedLayer.getModules(), false, includeVersion); // Modules
-        compareModuleItems(elementBuilder, originalLayer.getBundles(), updatedLayer.getBundles(), true, false);  // Bundles
+    static void compareLayer(final String layer, final PatchElementBuilder elementBuilder, final Distribution.ProcessedLayer originalLayer,
+            final Distribution.ProcessedLayer updatedLayer, boolean includeVersion) {
+        compareModuleItems(layer, elementBuilder, originalLayer.getModules(), updatedLayer.getModules(), false, includeVersion); // Modules
+        compareModuleItems(layer, elementBuilder, originalLayer.getBundles(), updatedLayer.getBundles(), true, false);  // Bundles
     }
 
     /**
@@ -208,7 +228,7 @@ abstract class PatchBuilderWrapper extends PatchBuilder {
      * @param updated        the updated module set
      * @param bundle         whether is a bundle or module
      */
-    static void compareModuleItems(final PatchElementBuilder elementBuilder, final Collection<DistributionModuleItem> original,
+    static void compareModuleItems(final String layer, final PatchElementBuilder elementBuilder, final Collection<DistributionModuleItem> original,
                                    final Collection<DistributionModuleItem> updated, boolean bundle, boolean includeVersion) {
 
         final Map<String, DistributionModuleItem> modules = new HashMap<String, DistributionModuleItem>();
@@ -219,6 +239,9 @@ abstract class PatchBuilderWrapper extends PatchBuilder {
         for (final DistributionModuleItem o : original) {
             final DistributionModuleItem n = modules.remove(o.getFullModuleName());
             if (n == null) {
+                if(elementBuilder == null) {
+                    throw processingError("missing patch-config for layer/add-on %s", layer);
+                }
                 if (bundle) {
                     elementBuilder.removeBundle(o.getName(), o.getSlot(), o.getMetadataHash());
                 } else {
@@ -226,6 +249,9 @@ abstract class PatchBuilderWrapper extends PatchBuilder {
                 }
             } else {
                 if (!Arrays.equals(n.getComparisonHash(), o.getComparisonHash())) {
+                    if(elementBuilder == null) {
+                        throw processingError("missing patch-config for layer/add-on %s", layer);
+                    }
                     if (bundle) {
                         elementBuilder.modifyBundle(n.getName(), n.getSlot(), o.getMetadataHash(), n.getMetadataHash());
                     } else {
@@ -235,17 +261,25 @@ abstract class PatchBuilderWrapper extends PatchBuilder {
                     // Treat the version module separately, since the comparison hash will ignore the version property in the manifest
                     if (includeVersion && n.getName().equals("org.jboss.as.version")) {
                         if (! Arrays.equals(o.getMetadataHash(), n.getMetadataHash())) {
+                            if(elementBuilder == null) {
+                                throw processingError("missing patch-config for layer/add-on %s", layer);
+                            }
                             elementBuilder.modifyModule(n.getName(), n.getSlot(), o.getMetadataHash(), n.getMetadataHash());
                         }
                     }
                 }
             }
         }
-        for (final DistributionModuleItem item : modules.values()) {
-            if (bundle) {
-                elementBuilder.addBundle(item.getName(), item.getSlot(), item.getMetadataHash());
-            } else {
-                elementBuilder.addModule(item.getName(), item.getSlot(), item.getMetadataHash());
+        if(!modules.isEmpty()) {
+            if(elementBuilder == null) {
+                throw processingError("missing patch-config for layer/add-on %s", layer);
+            }
+            for (final DistributionModuleItem item : modules.values()) {
+                if (bundle) {
+                    elementBuilder.addBundle(item.getName(), item.getSlot(), item.getMetadataHash());
+                } else {
+                    elementBuilder.addModule(item.getName(), item.getSlot(), item.getMetadataHash());
+                }
             }
         }
     }
@@ -256,19 +290,19 @@ abstract class PatchBuilderWrapper extends PatchBuilder {
      * @param o the original root
      * @param n the updated root
      */
-    static void compareMiscFiles(final ModificationBuilderTarget<?> builder, final DistributionContentItem o, final DistributionContentItem n) {
+    static void compareMiscFiles(final ModificationBuilderTarget<?> builder, final DistributionContentItem o, final DistributionContentItem n, FSPathElement optionalPaths) {
         if (o == null && n == null) {
             return;
         } else if (o != null && n == null) {
-            builder.removeFile(o.getName(), o.getParent().getPathAsList(), o.getMetadataHash(), !o.isLeaf());
+            builder.removeFile(o.getName(), o.getParent().getPathAsList(), o.getMetadataHash(), !o.isLeaf(), getCondition(optionalPaths, o));
         } else if (o == null && n != null) {
             boolean directory = !n.isLeaf();
             if (directory) {
                 for (final DistributionContentItem child : n.getChildren()) {
-                    compareMiscFiles(builder, null, child);
+                    compareMiscFiles(builder, null, child, optionalPaths);
                 }
             } else {
-                builder.addFile(n.getName(), n.getParent().getPathAsList(), n.getMetadataHash(), directory);
+                builder.addFile(n.getName(), n.getParent().getPathAsList(), n.getMetadataHash(), directory, getCondition(optionalPaths, n));
             }
         } else {
             if (!n.equals(o)) {
@@ -278,7 +312,7 @@ abstract class PatchBuilderWrapper extends PatchBuilder {
                 throw processingError("TODO");
             }
             if (n.isLeaf() && !Arrays.equals(o.getComparisonHash(), n.getComparisonHash())) {
-                builder.modifyFile(n.getName(), n.getParent().getPathAsList(), o.getMetadataHash(), n.getMetadataHash(), !n.isLeaf());
+                builder.modifyFile(n.getName(), n.getParent().getPathAsList(), o.getMetadataHash(), n.getMetadataHash(), !n.isLeaf(), getCondition(optionalPaths, o));
             } else {
 
                 final Collection<DistributionContentItem> nc = n.getChildren();
@@ -289,14 +323,139 @@ abstract class PatchBuilderWrapper extends PatchBuilder {
                 // compare
                 for (final DistributionContentItem child : o.getChildren()) {
                     final DistributionContentItem item = children.remove(child.getName());
-                    compareMiscFiles(builder, child, item);
+                    compareMiscFiles(builder, child, item, optionalPaths);
                 }
                 // compare missing
                 for (final DistributionContentItem child : children.values()) {
-                    compareMiscFiles(builder, null, child);
+                    compareMiscFiles(builder, null, child, optionalPaths);
                 }
             }
         }
     }
 
+    static ModificationCondition getCondition(FSPathElement optionalPaths, DistributionContentItem item) {
+        if(optionalPaths.children.isEmpty()) {
+            return null;
+        }
+        final FSPathElement e = new FSPathElement(optionalPaths);
+        final List<String> path = matchOptionalPath(e, item);
+        if(path == null) {
+            return null;
+        }
+        final MiscContentItem misc;
+        if(e.requires != null) {
+            misc = new MiscContentItem(e.requires[0], Arrays.asList(Arrays.copyOf(e.requires, e.requires.length - 1)), null, false);
+        } else {
+            misc = new MiscContentItem(e.name, path, null, true);
+        }
+        return ModificationCondition.Factory.exists(misc);
+    }
+
+    static List<String> matchOptionalPath(FSPathElement root, DistributionContentItem item) {
+        if(item.getParent() == null || item.getParent().name == null) {
+            final FSPathElement dir = root.children.get(item.getName());
+            if(dir != null) {
+                root.linkTo(dir);
+                return Collections.emptyList();
+            }
+            return null;
+        }
+        List<String> path = matchOptionalPath(root, item.getParent());
+        if(path == null) {
+            return null;
+        }
+        if(root.children.isEmpty()) {
+            return path;
+        }
+        final FSPathElement dir = root.children.get(item.getName());
+        if(dir != null) {
+            switch(path.size()) {
+                case 0:
+                    path = Collections.singletonList(root.name);
+                    break;
+                case 1:
+                    path = new ArrayList<String>(path);
+                default:
+                    path.add(root.name);
+            }
+            root.linkTo(dir);
+            return path;
+        }
+        return null;
+    }
+
+    private static final class FSPathElement {
+        private String name;
+        private Map<String, FSPathElement> children = Collections.emptyMap();
+        private String[] requires;
+
+        FSPathElement(String name) {
+            this(null, name);
+        }
+
+        FSPathElement(FSPathElement parent, String name) {
+            assert name != null : "name is null";
+            this.name = name;
+            if(parent != null) {
+                parent.addChild(this);
+            }
+        }
+
+        FSPathElement(FSPathElement linkTo) {
+            name = linkTo.name;
+            children = linkTo.children;
+        }
+
+        FSPathElement addChild(String... names) {
+            FSPathElement parent = this;
+            FSPathElement child = null;
+            for(String name : names) {
+                child = parent.children.get(name);
+                if(child == null) {
+                    child = new FSPathElement(parent, name);
+                }
+                parent = child;
+            }
+            return child;
+        }
+
+        boolean addChild(FSPathElement child) {
+//            if(children.containsKey(child.name)) {
+//                return false;
+//            }
+            switch(children.size()) {
+                case 0:
+                    children = Collections.singletonMap(child.name, child);
+                    break;
+                case 1:
+                    children = new HashMap<String, FSPathElement>(children);
+                default:
+                    children.put(child.name, child);
+            }
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            final StringBuilder buf = new StringBuilder();
+            toString(buf, 0);
+            return buf.toString();
+        }
+
+        private void toString(StringBuilder buf, int depth) {
+            for(int i = 0; i < depth; ++i) {
+                buf.append("  ");
+            }
+            buf.append(name).append("\n");
+            for(FSPathElement child : children.values()) {
+                child.toString(buf, depth + 1);
+            }
+        }
+
+        void linkTo(FSPathElement dir) {
+            this.name = dir.name;
+            this.children = dir.children;
+            this.requires = dir.requires;
+        }
+    }
 }

--- a/src/main/java/org/jboss/as/patching/generator/PatchBundleGenerator.java
+++ b/src/main/java/org/jboss/as/patching/generator/PatchBundleGenerator.java
@@ -25,6 +25,7 @@ package org.jboss.as.patching.generator;
 import static org.jboss.as.patching.generator.PatchGenerator.processingError;
 
 import javax.xml.stream.XMLStreamException;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -40,9 +41,9 @@ import java.util.Set;
 import java.util.UUID;
 
 import org.jboss.as.patching.IoUtils;
-import org.jboss.as.patching.PatchMessages;
 import org.jboss.as.patching.PatchingException;
 import org.jboss.as.patching.ZipUtils;
+import org.jboss.as.patching.logging.PatchLogger;
 import org.jboss.as.patching.metadata.BundledPatch;
 import org.jboss.as.patching.metadata.Patch;
 import org.jboss.as.patching.metadata.PatchBundleXml;
@@ -78,12 +79,12 @@ class PatchBundleGenerator {
                 } else if (arg.equals("--assemble-patch-bundle")) {
                     continue;
                 } else {
-                    System.err.println(PatchMessages.MESSAGES.argumentExpected(arg));
+                    System.err.println(PatchLogger.ROOT_LOGGER.argumentExpected(arg));
                     usage();
                     return;
                 }
             } catch (IndexOutOfBoundsException e) {
-                System.err.println(PatchMessages.MESSAGES.argumentExpected(arg));
+                System.err.println(PatchLogger.ROOT_LOGGER.argumentExpected(arg));
                 usage();
                 return;
             }
@@ -97,7 +98,7 @@ class PatchBundleGenerator {
             missing.add("--output");
         }
         if (! missing.isEmpty()) {
-            System.err.println(PatchMessages.MESSAGES.missingRequiredArgs(missing));
+            System.err.println(PatchLogger.ROOT_LOGGER.missingRequiredArgs(missing));
             return;
         }
 

--- a/src/main/java/org/jboss/as/patching/generator/PatchConfig.java
+++ b/src/main/java/org/jboss/as/patching/generator/PatchConfig.java
@@ -108,6 +108,16 @@ public interface PatchConfig {
     Collection<PatchElementConfig> getElements();
 
     /**
+     * Returns a collection of optional paths. I.e. filesystem paths for which
+     * patch updates should be generated and included but that might be missing
+     * in the target installation and in that case be skipped instead of aborting
+     * the whole patch altogether.
+     *
+     * @return  optional paths
+     */
+    Collection<OptionalPath> getOptionalPaths();
+
+    /**
      * Create a {@link PatchBuilderWrapper} whose basic metadata matches what's configured in this object.
      *
      * @return the patch builder

--- a/src/main/java/org/jboss/as/patching/generator/PatchConfigXml.java
+++ b/src/main/java/org/jboss/as/patching/generator/PatchConfigXml.java
@@ -42,16 +42,17 @@ public class PatchConfigXml {
     private static final XMLMapper MAPPER = XMLMapper.Factory.create();
     private static final PatchConfigXml_1_0 INSTANCE = new PatchConfigXml_1_0();
     private static final XMLInputFactory INPUT_FACTORY = XMLInputFactory.newInstance();
-    private static final QName ROOT_ELEMENT = new QName(Namespace.PATCH_1_0.getNamespace(), PatchConfigXml_1_0.Element.PATCH_CONFIG.name);
 
     static {
-        MAPPER.registerRootElement(ROOT_ELEMENT, INSTANCE);
+        MAPPER.registerRootElement(new QName(Namespace.PATCH_1_0.getNamespace(), PatchConfigXml_1_0.Element.PATCH_CONFIG.name), INSTANCE);
+        MAPPER.registerRootElement(new QName(Namespace.PATCH_1_2.getNamespace(), PatchConfigXml_1_0.Element.PATCH_CONFIG.name), INSTANCE);
     }
 
     enum Namespace {
 
         PATCH_1_0("urn:jboss:patch-config:1.0"),
-        UNKNOWN(null),;
+        PATCH_1_2("urn:jboss:patch-config:1.2"),
+        UNKNOWN(null);
 
         private final String namespace;
 

--- a/src/main/java/org/jboss/as/patching/generator/PatchConfigXml_1_0.java
+++ b/src/main/java/org/jboss/as/patching/generator/PatchConfigXml_1_0.java
@@ -67,7 +67,9 @@ class PatchConfigXml_1_0 implements XMLStreamConstants, XMLElementReader<PatchCo
         MODULES("modules"),
         NAME("name"),
         ONE_OFF("one-off"),
+        OPTIONAL_PATHS("optional-paths"),
         PATCH_CONFIG("patch-config"),
+        PATH("path"),
         REMOVED("removed"),
         SPECIFIED_CONTENT("specified-content"),
         UPDATED("updated"),
@@ -106,8 +108,10 @@ class PatchConfigXml_1_0 implements XMLStreamConstants, XMLElementReader<PatchCo
         NAME("name"),
         PATCH_ID("patch-id"),
         PATH("path"),
+        REQUIRES("requires"),
         RESULTING_VERSION("resulting-version"),
         SLOT("slot"),
+        VALUE("value"),
 
         // default unknown attribute
         UNKNOWN(null);
@@ -164,6 +168,9 @@ class PatchConfigXml_1_0 implements XMLStreamConstants, XMLElementReader<PatchCo
                     break;
                 case MISC_FILES:
                     parseMiscFiles(reader, patchConfigBuilder);
+                    break;
+                case OPTIONAL_PATHS:
+                    parseOptionalPaths(reader, patchConfigBuilder);
                     break;
                 default:
                     throw unexpectedElement(reader);
@@ -597,7 +604,7 @@ class PatchConfigXml_1_0 implements XMLStreamConstants, XMLElementReader<PatchCo
                                        final PatchConfigBuilder builder) throws XMLStreamException {
 
         String path = null;
-        boolean directory = false;
+        boolean directory;
         boolean affectsRuntime = false;
 
         final int count = reader.getAttributeCount();
@@ -634,6 +641,38 @@ class PatchConfigXml_1_0 implements XMLStreamConstants, XMLElementReader<PatchCo
         builder.getSpecifiedContent().add(item);
     }
 
+    private void parseOptionalPaths(final XMLExtendedStreamReader reader, final PatchConfigBuilder builder) throws XMLStreamException {
+        while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+            final Element element = Element.forName(reader.getLocalName());
+            switch (element) {
+                case PATH:
+                    parseOptionalPath(reader, builder);
+                    break;
+                default:
+                    throw unexpectedElement(reader);
+            }
+        }
+    }
 
-
+    private void parseOptionalPath(final XMLExtendedStreamReader reader, final PatchConfigBuilder builder) throws XMLStreamException {
+        final int count = reader.getAttributeCount();
+        String value = null;
+        String requires = null;
+        for (int i = 0; i < count; i++) {
+            final String attrValue = reader.getAttributeValue(i);
+            final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
+            switch (attribute) {
+                case VALUE:
+                    value = attrValue;
+                    break;
+                case REQUIRES:
+                    requires = attrValue;
+                    break;
+                default:
+                    throw unexpectedAttribute(reader, i);
+            }
+        }
+        builder.addOptionalPath(value, requires);
+        requireNoContent(reader);
+    }
 }

--- a/src/main/java/org/jboss/as/patching/generator/TemplateGenerator.java
+++ b/src/main/java/org/jboss/as/patching/generator/TemplateGenerator.java
@@ -29,7 +29,7 @@ import java.io.Writer;
 import java.util.UUID;
 
 import org.jboss.as.patching.IoUtils;
-import org.jboss.as.patching.PatchMessages;
+import org.jboss.as.patching.logging.PatchLogger;
 
 /**
  * Generate a simple template for a give patch type.
@@ -78,12 +78,12 @@ class TemplateGenerator {
                 } else if (arg.equals("--create-template")) {
                     continue;
                 } else {
-                    System.err.println(PatchMessages.MESSAGES.argumentExpected(arg));
+                    System.err.println(PatchLogger.ROOT_LOGGER.argumentExpected(arg));
                     usage();
                     return null;
                 }
             } catch (IndexOutOfBoundsException e) {
-                System.err.println(PatchMessages.MESSAGES.argumentExpected(arg));
+                System.err.println(PatchLogger.ROOT_LOGGER.argumentExpected(arg));
                 usage();
                 return null;
             }

--- a/src/test/java/org/jboss/as/patching/generator/PatchConfigXmlUnitTestCase.java
+++ b/src/test/java/org/jboss/as/patching/generator/PatchConfigXmlUnitTestCase.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -204,6 +205,29 @@ public class PatchConfigXmlUnitTestCase {
 //
 //        Set<String> validInUse = new HashSet<String>(Arrays.asList("test/file3", "test/file5"));
 //        validateInRuntimeUse(patchConfig, validInUse);
+    }
+
+    @Test
+    public void testOptionalPaths() throws Exception {
+
+        final InputStream is = getResource("test-optional-paths.xml");
+        final PatchConfig patchConfig = PatchConfigXml.parse(is);
+        // Patch
+        assertNotNull(patchConfig);
+        assertEquals("patch-12345", patchConfig.getPatchId());
+        assertEquals("patch description", patchConfig.getDescription());
+        assertNotNull(patchConfig.getPatchType());
+        assertEquals(Patch.PatchType.CUMULATIVE, patchConfig.getPatchType());
+        assertTrue(patchConfig.isGenerateByDiff());
+        assertEquals("2.3.4", patchConfig.getResultingVersion());
+
+        validateAppliesTo(patchConfig, "1.2.3");
+
+        final Collection<OptionalPath> optionalPaths = patchConfig.getOptionalPaths();
+        assertEquals(3, optionalPaths.size());
+        optionalPaths.contains(OptionalPath.create("docs"));
+        optionalPaths.contains(OptionalPath.create("dir/appclient"));
+        optionalPaths.contains(OptionalPath.create("bin/appclient.txt", "dir/appclient"));
     }
 
     private static InputStream getResource(String name) throws IOException {

--- a/src/test/resources/test-optional-paths.xml
+++ b/src/test/resources/test-optional-paths.xml
@@ -1,0 +1,37 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<patch-config xmlns="urn:jboss:patch-config:1.2">
+
+    <name>patch-12345</name>
+    <description>patch description</description>
+    <cumulative name="Test" applies-to-version="1.2.3" resulting-version="2.3.4"/>
+
+    <generate-by-diff/>
+
+    <optional-paths>
+        <path value="docs"/>
+        <path value="dir/appclient"/>
+        <path value="bin/appclient.txt" requires="dir/appclient"/>
+    </optional-paths>
+</patch-config>


### PR DESCRIPTION
This commit merges the following fixes and features from a branch of mine forked from emuckenhuber/patch-gen:

- allow skipping layers/add-ons in patch-config xml that were not modified in the target version, if the layer/add-on was modified but is missing from the patch-config xml the patch generation process should fail;
- generation of compact CPs implemented under https://issues.jboss.org/browse/WFCORE-838;
- support for modification conditions implemented as part of https://issues.jboss.org/browse/WFCORE-896 Cannot patch EAP once Docs are excluded from installation.