### PR TITLE
Plug-in - Follow up

### DIFF
--- a/patch-gen-maven-plugin/pom.xml
+++ b/patch-gen-maven-plugin/pom.xml
@@ -25,6 +25,7 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <version>2.0</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>

--- a/patch-gen-maven-plugin/src/main/java/org/jboss/as/patch/generator/maven/plugin/PatchGenMojo.java
+++ b/patch-gen-maven-plugin/src/main/java/org/jboss/as/patch/generator/maven/plugin/PatchGenMojo.java
@@ -68,7 +68,7 @@ import org.jboss.as.patching.generator.PatchGenerator;
  *
  * @author Gunnar Morling
  */
-@Mojo( name = "GenPatch", defaultPhase = LifecyclePhase.GENERATE_RESOURCES )
+@Mojo( name = "generate-patch", defaultPhase = LifecyclePhase.GENERATE_RESOURCES )
 public class PatchGenMojo extends AbstractMojo {
 
     @Parameter( property = "patchConfig", required = true )


### PR DESCRIPTION
Hi @aloubyansky, that's the follow-up work I've been mentioning. It does two things:

* change the goal name into "generate-patch"
* Execute the patch-gen tool in a separate process, due to [MODULES-136](https://issues.jboss.org/browse/MODULES-136). Essentially, JBoss Modules alters some system properties which then causes other plug-ins running later on to fail. That's prevented by running the tool in its own process.