### PR TITLE
Check whether the specified directory is a valid server distribution directory.

### DIFF
--- a/patch-gen/src/main/java/org/jboss/as/patching/generator/DistributionProcessor.java
+++ b/patch-gen/src/main/java/org/jboss/as/patching/generator/DistributionProcessor.java
@@ -77,6 +77,9 @@ class DistributionProcessor {
             }
         }
 
+        if (processor.moduleRoots.isEmpty()) {
+            throw new IOException(distributionRoot.getAbsolutePath() + " is not a valid server distribution directory.");
+        }
         final List<File> mp = new ArrayList<File>();
         final Set<DistributionContentItem> moduleRoots = processor.moduleRoots;
         for (final DistributionContentItem item : moduleRoots) {


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/JBEAP-6243

The Jira issue complains that the patch-gen should display more friendly message about whether the specified directory is a valid server distribution directory.

I did not find Jira project for patch-gen, so I linked the JBEAP issue.

@aloubyansky  Could you please take a look at this?