### PR TITLE
Fix add-ons root path

### DIFF
--- a/patch-gen/src/main/java/org/jboss/as/patching/generator/DistributionProcessor.java
+++ b/patch-gen/src/main/java/org/jboss/as/patching/generator/DistributionProcessor.java
@@ -194,11 +194,12 @@ class DistributionProcessor {
             context.addLayer(newParent, layer, layerDir);
         }
         // Finally process the add-ons
+        final DistributionContentItem addOnsParent = DistributionStructureImpl.createMiscItem(parent, layersConfig.getAddOnsPath());
         final File addOnsDir = new File(root, layersConfig.getAddOnsPath());
         final File[] addOnsList = addOnsDir.listFiles();
         if (addOnsList != null) {
             for (final File addOn : addOnsList) {
-                context.addAddOn(newParent, addOn.getName(), addOn);
+                context.addAddOn(addOnsParent, addOn.getName(), addOn);
             }
         }
     }


### PR DESCRIPTION
* add-ons root path is pointing to system/layers instead of system/add-ons

When creating a patch for Infinispan server, the `patch.xml` generated has:

```
<upgrade name="WildFly" .../>
```

instead of Infinispan. 