### PR TITLE
update wildfly-core to 15.0.0.Final

### DIFF
--- a/patch-gen/pom.xml
+++ b/patch-gen/pom.xml
@@ -54,6 +54,16 @@
                         <configuration>
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadedClassifierName>shaded</shadedClassifierName>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
             For example: <version.org.jboss.as.console>
          -->
 
-        <version.org.wildfly-core>5.0.0.Final</version.org.wildfly-core>
+        <version.org.wildfly-core>15.0.0.Final</version.org.wildfly-core>
         <version.org.apache.maven.shared.maven-shared-utils>3.1.0</version.org.apache.maven.shared.maven-shared-utils>
         <version.org.apache.maven.plugin-tools.maven-plugin-annotations>3.2</version.org.apache.maven.plugin-tools.maven-plugin-annotations>
         <version.org.apache.maven.maven-plugin-api>2.0</version.org.apache.maven.maven-plugin-api>


### PR DESCRIPTION
wildfly-core 5.0.0.Final uses jboss-modules 1.8.5.Final and this version of jboss-modules supports up to
urn:jboss:module:1.8. Wildfly-core uses jboss-modules 1.11.0.Final and this version already supports
urn:jboss:module:1.9.

This change is required for wildfly 7.4.0.GA as it uses urn:jboss:module:1.9.