### PR TITLE
[JBEAP-23777] Allow to define one-off patch with name and version separated from base server in patch-config file.

### DIFF
--- a/patch-gen/src/main/java/org/jboss/as/patching/generator/PatchConfigXml.java
+++ b/patch-gen/src/main/java/org/jboss/as/patching/generator/PatchConfigXml.java
@@ -47,6 +47,8 @@ public class PatchConfigXml {
         MAPPER.registerRootElement(new QName(Namespace.PATCH_1_0.getNamespace(), PatchConfigXml_1_0.Element.PATCH_CONFIG.name), INSTANCE);
         MAPPER.registerRootElement(new QName(Namespace.PATCH_1_2.getNamespace(), PatchConfigXml_1_0.Element.PATCH_CONFIG.name), INSTANCE);
         MAPPER.registerRootElement(new QName(Namespace.PATCH_1_3.getNamespace(), PatchConfigXml_1_0.Element.PATCH_CONFIG.name), INSTANCE);
+        MAPPER.registerRootElement(new QName(Namespace.PATCH_1_4.getNamespace(), PatchConfigXml_1_0.Element.PATCH_CONFIG.name), INSTANCE);
+
     }
 
     enum Namespace {
@@ -54,6 +56,7 @@ public class PatchConfigXml {
         PATCH_1_0("urn:jboss:patch-config:1.0"),
         PATCH_1_2("urn:jboss:patch-config:1.2"),
         PATCH_1_3("urn:jboss:patch-config:1.3"),
+        PATCH_1_4("urn:jboss:patch-config:1.4"),
         UNKNOWN(null);
 
         private final String namespace;

--- a/patch-gen/src/main/java/org/jboss/as/patching/generator/PatchConfigXml_1_0.java
+++ b/patch-gen/src/main/java/org/jboss/as/patching/generator/PatchConfigXml_1_0.java
@@ -443,6 +443,7 @@ class PatchConfigXml_1_0 implements XMLStreamConstants, XMLElementReader<PatchCo
 
         String name = null;
         String appliesTo = null;
+        boolean overrideIdentity = false;
 
         Set<Attribute> required = Collections.emptySet(); // EnumSet.of(Attribute.APPLIES_TO_VERSION, Attribute.RESULTING_VERSION);
 
@@ -458,6 +459,9 @@ class PatchConfigXml_1_0 implements XMLStreamConstants, XMLElementReader<PatchCo
                 case APPLIES_TO_VERSION:
                     appliesTo = value;
                     break;
+                case OVERRIDE_IDENTITY:;
+                    overrideIdentity = Boolean.parseBoolean(value);
+                    break;
                 default:
                     throw unexpectedAttribute(reader, i);
             }
@@ -469,8 +473,17 @@ class PatchConfigXml_1_0 implements XMLStreamConstants, XMLElementReader<PatchCo
             throw missingRequired(reader, required);
         }
 
+        if (overrideIdentity && (name == null || appliesTo == null)) {
+            String msg = String.format("When %s=\"true\", all of %s and %s must be set",
+                    Attribute.OVERRIDE_IDENTITY.name,
+                    Attribute.NAME.name,
+                    Attribute.APPLIES_TO_VERSION.name);
+            throw new XMLStreamException(msg, reader.getLocation());
+        }
+
         builder.setOneOffType(appliesTo);
         builder.setAppliesToName(name);
+        builder.setOverrideIdentity(overrideIdentity);
 
         patchTypeConfigured = true;
     }

--- a/patch-gen/src/main/java/org/jboss/as/patching/generator/PatchGenerator.java
+++ b/patch-gen/src/main/java/org/jboss/as/patching/generator/PatchGenerator.java
@@ -165,7 +165,13 @@ public class PatchGenerator {
                 }
                 builder.upgradeIdentity(name, version, toVersion);
             } else {
-                builder.oneOffPatchIdentity(base.getName(), base.getVersion());
+                if (patchConfig.isOverrideIdentity()) {
+                    // This allows to build one-off patch based on "name" and "applies-to-version", to e.g.
+                    // have a totally separately named and versioned patch stream from the servers used to create the diff.
+                    builder.oneOffPatchIdentity(patchConfig.getAppliesToProduct(), patchConfig.getAppliesToVersion());
+                } else {
+                    builder.oneOffPatchIdentity(base.getName(), base.getVersion());
+                }
             }
 
             // Create the resulting patch

--- a/patch-gen/src/main/resources/schema/patch-config_1_4.xsd
+++ b/patch-gen/src/main/resources/schema/patch-config_1_4.xsd
@@ -1,0 +1,371 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="urn:jboss:patch-config:1.4"
+           targetNamespace="urn:jboss:patch-config:1.4"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+        >
+
+    <xs:element name="patch-config">
+        <xs:annotation>
+            <xs:documentation>
+                Patch description
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <!--xs:element name="id" type="patchIdType" minOccurs="1" maxOccurs="1"/-->
+                <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                <xs:choice>
+                    <xs:element name="cumulative" type="cumulative-patchType" maxOccurs="1"/>
+                    <xs:element name="one-off" type="patchType" maxOccurs="1"/>
+                </xs:choice>
+                <xs:element name="element" type="elementType" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:choice>
+                    <xs:element name="generate-by-diff" type="generate-by-diffType" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="specified-content" type="specified-contentType" minOccurs="0" maxOccurs="1"/>
+                </xs:choice>
+                <xs:element name="optional-paths" type="optional-pathsType" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="patchType">
+        <xs:annotation>
+            <xs:documentation>
+                Describes the type of the patch
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Identifier of the project or product name to which this patch applies.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="applies-to-version" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Identifier of the project or product version to which this patch applies.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="override-identity" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    If true, allows us to change the values of name, applies-to-version, to e.g.
+                    have a totally separately named and versioned patch stream from the servers used to create the diff.
+                    If false (default) it verifies that those values match those of the inspected servers specified by
+                    the --applies-to-dist and --updated-dist command line arguments, and uses those determined values.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="cumulative-patchType">
+        <xs:annotation>
+            <xs:documentation>
+                Cumulative patch release, invalidating all previous one-off patches
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="skip-misc-files" minOccurs="0" maxOccurs="1" type="skipMiscFilesType"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Identifier of the project or product name to which this patch applies.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="applies-to-version" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Identifier of the project or product version to which this patch applies.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="resulting-version" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Identifier of the project or product version that will be installed once this patch is applied.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="skip-non-configured-layers" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    If true, it is possible to create patches which do not include the base (and other) layers.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="override-identity" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    If true, allows us to change the values of name, applies-to-version and resulting-version, to e.g.
+                    have a totally separately named and versioned patch stream from the servers used to create the diff.
+                    If false (default) it verifies that those values match those of the inspected servers specified by
+                    the --applies-to-dist and --updated-dist command line arguments, and uses those determined values.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="generate-by-diffType">
+        <xs:annotation>
+            <xs:documentation>
+                Indicates the patch should be generated by comparing the contents of two distributions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="in-runtime-use" type="contentType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="specified-contentType">
+        <xs:annotation>
+            <xs:documentation>
+                Indicates the patch should be generated by using the specifically identified herein.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="modules" type="modulesType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="bundles" type="bundlesType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="misc-files" type="misc-filesType" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="modulesType">
+        <xs:sequence>
+            <xs:element name="added" type="slotted-contentType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="updated" type="slotted-contentType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="removed" type="slotted-contentType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="bundlesType">
+        <xs:sequence>
+            <xs:element name="added" type="slotted-contentType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="updated" type="slotted-contentType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="removed" type="slotted-contentType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="misc-filesType">
+        <xs:sequence>
+            <xs:element name="added" type="added-misc-contentType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="updated" type="updated-misc-contentType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="removed" type="removed-misc-contentType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="contentType">
+        <xs:annotation>
+            <xs:documentation>
+                A piece of patch content.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="path" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Location of the content within the patch file.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="slotted-contentType">
+        <xs:annotation>
+            <xs:documentation>
+                A piece of patch content with a name and a slot.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string"/>
+        <xs:attribute name="slot" type="xs:string"/>
+        <xs:attribute name="search-path" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the searchable path under which the slotted content is stored. If not set, the
+                    default path for the type of content (e.g. modules/ or bundles/) is assumed
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="added-misc-contentType">
+        <xs:annotation>
+            <xs:documentation>
+                Miscellaneous content that the patch adds to the installation.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="contentType">
+                <xs:attribute name="directory" type="xs:boolean" use="optional" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whether the added content is a directory.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="updated-misc-contentType">
+        <xs:annotation>
+            <xs:documentation>
+                Miscellaneous content in the installation being patched that the patch modifies.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="contentType">
+                <xs:attribute name="directory" type="xs:boolean" use="optional" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whether the new version of the content is a directory.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="in-runtime-use" type="xs:boolean">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whether the content is expected to be in use by a non-admin-only standalone server or Host Controller.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="removed-misc-contentType">
+        <xs:annotation>
+            <xs:documentation>
+                Miscellaneous content in the installation being patched that the patch removes.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="path" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Location of the content within the patch file.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="directory" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Whether the removed content is a directory
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="in-runtime-use" type="xs:boolean">
+            <xs:annotation>
+                <xs:documentation>
+                    Whether the content is expected to be in use by a non-admin-only standalone server or Host Controller.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="elementPatchType">
+        <xs:attribute name="name" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The layer name.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="elementType">
+        <xs:sequence>
+            <xs:choice>
+                <xs:element name="cumulative" type="elementPatchType" maxOccurs="1"/>
+                <xs:element name="one-off" type="elementPatchType" maxOccurs="1"/>
+            </xs:choice>
+            <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="specified-content" type="specified-contentType" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="patch-id" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The element patch-id.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="optional-pathsType">
+        <xs:annotation>
+            <xs:documentation>
+                Lists filesystem paths that belong to the miscellaneous content
+                for which the patch should be generated but which could be abscent in the target
+                installation (chosen not to be installed by the user, for example) and in that
+                case should simply be skipped instead of aborting the patch altogether.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="path" type="optionalPathType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="optionalPathType">
+        <xs:attribute name="value" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Path relative to the installation root with '/' as a name-separator character
+                    which may be skipped during patch application if the path does not exist
+                    in the target installation.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="requires" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Path relative to the installation root with '/' as a name-separator character
+                    which is required to exist for the path specified in 'value' attribute
+                    to be patched. If 'requires' path does not exist at patch application
+                    then patching 'value' path will be skipped, otherwise, 'value' path
+                    will become a reuquired path to patch.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="skipMiscFilesType">
+        <xs:annotation>
+            <xs:documentation>If present the resulting patch will not include misc files, unless included</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="exception" minOccurs="0" maxOccurs="unbounded" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>
+                        Regexp matching one or more misc files that should be included anyway
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+
+</xs:schema>

--- a/patch-gen/src/test/java/org/jboss/as/patching/generator/PatchConfigXmlUnitTestCase.java
+++ b/patch-gen/src/test/java/org/jboss/as/patching/generator/PatchConfigXmlUnitTestCase.java
@@ -40,6 +40,8 @@ import java.util.Set;
 import org.jboss.as.patching.metadata.Patch;
 import org.junit.Test;
 
+import javax.xml.stream.XMLStreamException;
+
 /**
  * @author Brian Stansberry (c) 2012 Red Hat Inc.
  */
@@ -81,6 +83,33 @@ public class PatchConfigXmlUnitTestCase {
         validateAppliesTo(patchConfig, "1.2.3");
 
         validateInRuntimeUse(patchConfig);
+    }
+
+    @Test
+    public void testOneOffGeneratedWithOverride() throws Exception {
+
+        final InputStream is = getResource("test-config05.xml");
+        final PatchConfig patchConfig = PatchConfigXml.parse(is);
+        // Patch
+        assertNotNull(patchConfig);
+        assertEquals("patch-12345", patchConfig.getPatchId());
+        assertEquals("patch description", patchConfig.getDescription());
+        assertEquals("Test", patchConfig.getAppliesToProduct());
+        assertEquals(true, patchConfig.isOverrideIdentity());
+
+        assertNotNull(patchConfig.getPatchType());
+        assertEquals(Patch.PatchType.ONE_OFF, patchConfig.getPatchType());
+        assertTrue(patchConfig.isGenerateByDiff());
+        assertNull(patchConfig.getResultingVersion());
+
+        validateAppliesTo(patchConfig, "1.2.3");
+    }
+
+    @Test(expected = XMLStreamException.class)
+    // Missing required name and applies-to-version attributes cause an exception.
+    public void testOneOffGeneratedRequiredAttribute() throws Exception {
+        final InputStream is = getResource("test-config06.xml");
+        final PatchConfig patchConfig = PatchConfigXml.parse(is);
     }
 
     @Test

--- a/patch-gen/src/test/resources/test-config05.xml
+++ b/patch-gen/src/test/resources/test-config05.xml
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2022, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<patch-config xmlns="urn:jboss:patch-config:1.4">
+
+    <name>patch-12345</name>
+    <description>patch description</description>
+    <one-off name="Test" applies-to-version="1.2.3" override-identity="true"/>
+
+</patch-config>

--- a/patch-gen/src/test/resources/test-config06.xml
+++ b/patch-gen/src/test/resources/test-config06.xml
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2022, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<patch-config xmlns="urn:jboss:patch-config:1.4">
+
+    <name>patch-12345</name>
+    <description>patch description</description>
+    <one-off override-identity="true"/>
+
+</patch-config>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-23777

please see more information in the issue. thanks.

@kabir please review