### PR TITLE
Workaround for removal of deprecated ProductConfig constructor.

### DIFF
--- a/patch-gen/src/main/java/org/jboss/as/patching/generator/DistributionProcessor.java
+++ b/patch-gen/src/main/java/org/jboss/as/patching/generator/DistributionProcessor.java
@@ -95,13 +95,16 @@ class DistributionProcessor {
             final Class<?> clazz = module.getClassLoader().loadClass("org.jboss.as.version.ProductConfig");
             final Method resolveName = clazz.getMethod("resolveName");
             final Method resolveVersion  = clazz.getMethod("resolveVersion");
-            final Constructor<?> constructor = clazz.getConstructor(ModuleLoader.class, String.class, Map.class);
-
-            final Object productConfig = constructor.newInstance(loader, distributionRoot.getAbsolutePath(), Collections.emptyMap());
-
+            Object productConfig = null;
+            try {
+                final Method fromFilesystemSlot = clazz.getMethod("fromFilesystemSlot", ModuleLoader.class, String.class, Map.class);
+                productConfig = fromFilesystemSlot.invoke(null, loader, distributionRoot.getAbsolutePath(), Collections.emptyMap());
+            } catch (NoSuchMethodException e) {
+                final Constructor<?> constructor = clazz.getConstructor(ModuleLoader.class, String.class, Map.class);
+                productConfig = constructor.newInstance(loader, distributionRoot.getAbsolutePath(), Collections.emptyMap());
+            }
             distribution.setName((String) resolveName.invoke(productConfig));
             distribution.setVersion((String) resolveVersion.invoke(productConfig));
-
         } catch (Exception e) {
             throw new IOException(e);
         }


### PR DESCRIPTION
This fixes the patch-gen for Wildfly 30.0.0.Final which no longer has the constructor called by DistributionProcessor.

See: https://github.com/wildfly/wildfly-core/commit/01460071c0033917e349d6ee1db99875e18aba58
